### PR TITLE
Use `ruff check .` instead of older `ruff .` that no longer works

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ description = Lint with ruff
 base_python = py312
 extras = lint
 commands =
-    ruff .
+    ruff check .
 
 [testenv:mypy-py{37,38,39,310,311,312}]
 description = Typecheck with mypy


### PR DESCRIPTION
See errors in #6.