### PR TITLE
Update versions tested in tox and on CI

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -6,6 +6,9 @@ on:
   schedule:
   - cron: '15 0,12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     name: Check links
@@ -14,7 +17,7 @@ jobs:
     - name: Check out source repository
       uses: actions/checkout@v4
     - name: Check Markdown links
-      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
+      uses: tcort/github-action-markdown-link-check@v1
 
   markdownlint-cli2:
     name: Lint

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -49,8 +49,6 @@ jobs:
         - python-version: '3.14'
           experimental: true
 
-      fail-fast: false
-
     runs-on: ${{ matrix.os }}
 
     defaults:
@@ -75,3 +73,18 @@ jobs:
 
     - name: Check with tox
       run: tox --root ${{ matrix.package }}
+
+  all-pass:
+    name: All tox checks pass
+
+    needs: [tox]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Some failed
+      if: contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')
+      run: false
+
+    - name: All passed
+      run: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,20 +2,54 @@ name: Tox
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   tox:
     strategy:
       matrix:
         package: [by_literal, by_getattr, by_property]
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+
+        os:
+        - ubuntu-22.04  # For Python 3.7 only (unavailable on >= 24.04).
+        - ubuntu-latest
+        - macos-13  # These images are x86-64 (amd64).
+        - macos-15  # These images are Apple Silicon (aarch64, amd64).
+        - windows-latest
+
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+
         exclude:
-        - os: macos-14
-          python-version: '3.7'
-        - os: macos-14
+        # Use Ubuntu 22.04 only to test Python 3.7, and no other Pythons.
+        - os: ubuntu-22.04
           python-version: '3.8'
-        - os: macos-14
+        - os: ubuntu-22.04
           python-version: '3.9'
+        - os: ubuntu-22.04
+          python-version: '3.10'
+        - os: ubuntu-22.04
+          python-version: '3.11'
+        - os: ubuntu-22.04
+          python-version: '3.12'
+        - os: ubuntu-22.04
+          python-version: '3.13'
+        - os: ubuntu-22.04
+          python-version: '3.14'
+
+        # Python 3.7 is not available on some newer systems.
+        - os: ubuntu-latest
+          python-version: '3.7'
+        - os: macos-15
+          python-version: '3.7'
+
+        include:
+        - experimental: false
+
+        - python-version: '3.14'
+          experimental: true
+
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 
@@ -31,9 +65,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: ${{ matrix.experimental }}
 
     - name: Upgrade PyPA packages
-      run: python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
+      run: python -m pip install -U pip 'setuptools; python_version<"3.12"' wheel
 
     - name: Install tox and plugins
       run: pip install -U 'tox==4.*' 'tox-gh-actions==3.*'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox>=4
 skip_missing_interpreters = false
-env_list = ruff, {,mypy-,pyright-}py{37,38,39,310,311,312}
+env_list = ruff, {,mypy-,pyright-}py{37,38,39,310,311,312,313,314}
 
 [gh-actions]
 python =
@@ -10,7 +10,9 @@ python =
     3.9: py39, mypy-py39, pyright-py39
     3.10: py310, mypy-py310, pyright-py310
     3.11: py311, mypy-py311, pyright-py311
-    3.12: ruff, py312, mypy-py312, pyright-py312
+    3.12: py312, mypy-py312, pyright-py312
+    3.13: ruff, py313, mypy-py313, pyright-py313
+    3.14: py314, mypy-py314, pyright-py314
 
 [testenv]
 description = Run unit tests
@@ -21,19 +23,19 @@ commands =
 
 [testenv:ruff]
 description = Lint with ruff
-base_python = py312
+base_python = py313
 extras = lint
 commands =
     ruff check .
 
-[testenv:mypy-py{37,38,39,310,311,312}]
+[testenv:mypy-py{37,38,39,310,311,312,313,314}]
 description = Typecheck with mypy
 extras = typecheck
 commands =
     python -V
     mypy --exclude=build .
 
-[testenv:pyright-py{37,38,39,310,311,312}]
+[testenv:pyright-py{37,38,39,310,311,312,313,314}]
 description = Typecheck with pyright
 extras = typecheck
 commands =


### PR DESCRIPTION
Changes:

- On CI, use macOS 15 instead of macOS 14 (but keep macOS 13).
- On CI, test 3.7, but no other versions, on Ubuntu 22.04.
- On CI, don't test 3.7 on systems where it's unavailable.
- On tox and CI, add 3.13 (and run `ruff` on it instead of 3.12).
- On tox and CI, add 3.14 (currently beta), allowing prereleases.
- On CI, make specify conditional `setuptools` statically.
- Specify explicit `contents: read`-only workflow permissions.
- Switch to maintained fork of `markdown-link-check` action.

This also adds a collector job to help with auto-merge.