### PR TITLE
Refine `license` and `classifiers` metadata

### DIFF
--- a/by_getattr/pyproject.toml
+++ b/by_getattr/pyproject.toml
@@ -11,8 +11,15 @@ authors = [
 description = "Package that gets its __version__ dynamically with __getattr__"
 readme = "README.md"
 requires-python = ">= 3.7"
-license = {file = "LICENSE"}
-classifiers = ["Programming Language :: Python :: 3"]
+license = "0BSD"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Zero-Clause BSD (0BSD)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Typing :: Typed",
+]
 dependencies = [
     "importlib_metadata >=6.7, <6.8 ; python_version < '3.8'",
     "typing-extensions >=4.7, <4.8 ; python_version < '3.8'",

--- a/by_literal/pyproject.toml
+++ b/by_literal/pyproject.toml
@@ -11,8 +11,15 @@ authors = [
 description = "Package that gets its __version__ by defining it in code"
 readme = "README.md"
 requires-python = ">= 3.7"
-license = {file = "LICENSE"}
-classifiers = ["Programming Language :: Python :: 3"]
+license = "0BSD"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Zero-Clause BSD (0BSD)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Typing :: Typed",
+]
 dependencies = []
 
 [project.optional-dependencies]

--- a/by_property/pyproject.toml
+++ b/by_property/pyproject.toml
@@ -11,8 +11,15 @@ authors = [
 description = "Package that gets its __version__ dynamically with a property"
 readme = "README.md"
 requires-python = ">= 3.7"
-license = {file = "LICENSE"}
-classifiers = ["Programming Language :: Python :: 3"]
+license = "0BSD"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Zero-Clause BSD (0BSD)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Typing :: Typed",
+]
 dependencies = [
     "importlib_metadata >=6.7, <6.8 ; python_version < '3.8'",
 ]


### PR DESCRIPTION
This sets `project.license` (in all three demo projects) to the SPDX license name string `"0BSD"` and adds the corresponding classifier for that license, instead of using `{file = "LICENSE"}`, because:

- PyPI has such a classifier (so doing it this way would no longer demonstrate something that people would likely not want to do in practice).

- `setuptools` has deprecated the user of `{file = ...}` as a value of `project.license`, and it shall eventually no longer be supported. (`license_files` is available, but older versions of `setuptools` that one may have to use when still supporting EoL Python versions such as 3.7 do not support it.)

This also adds some other relevant classifiers at the same time.