### PR TITLE
Change retired `macos-13` runner to `macos-15-intel`

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,8 +14,8 @@ jobs:
         os:
         - ubuntu-22.04  # For Python 3.7 only (unavailable on >= 24.04).
         - ubuntu-latest
-        - macos-13  # These images are x86-64 (amd64).
-        - macos-15  # These images are Apple Silicon (aarch64, amd64).
+        - macos-15-intel  # These images are x86-64 (amd64).
+        - macos-15  # These images are Apple Silicon (aarch64, arm64).
         - windows-latest
 
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
@@ -46,8 +46,8 @@ jobs:
         include:
         - experimental: false
 
-        - python-version: '3.14'
-          experimental: true
+        # - python-version: '3.14'
+        #   experimental: true
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The `macos-13` runner was previously the way to run CI jobs on an x86_64 (Intel) build of macOS. But it has since been deprecated and subsequently retired. When it was deprecated, `macos-15-intel` was introduced, which should be used instead. This makes that change to fix CI failures such as the failure seen initially here in #21.

See https://github.com/actions/runner-images/issues/13046 for more information on these runner images.

This PR also marks Python 3.14 non-experimental.